### PR TITLE
Bump version from 1.2.4 to 1.2.5

### DIFF
--- a/src/folsomite.app.src
+++ b/src/folsomite.app.src
@@ -2,7 +2,7 @@
 {application, folsomite,
  [
   {description, "Blow up your Graphite server with Folsom metrics"},
-  {vsn, "1.2.4"},
+  {vsn, "1.2.5"},
   {registered, [folsomite_sup,
                 folsomite_server,
                 folsomite_graphite_client_sup


### PR DESCRIPTION
Due to increasing the reconnect period when connect fails.