### PR TITLE
Make the common prefix configurable

### DIFF
--- a/src/folsomite.app.src
+++ b/src/folsomite.app.src
@@ -15,6 +15,7 @@
   {env, [{graphite_host, "localhost"},
          {graphite_port, 2003},
          {flush_interval, 60000},
-         {tags, []}
+         {tags, []},
+         {common_prefix, "folsomite"}
         ]}
  ]}.

--- a/src/folsomite_server.erl
+++ b/src/folsomite_server.erl
@@ -123,7 +123,8 @@ send_stats(State) ->
     end.
 
 format1(Base, {K, V}, Timestamp) ->
-    ["folsomite.", Base, ".", space2dot(K), " ", a2l(V), " ", Timestamp, "\n"].
+    [application:get_env(?APP, common_prefix, "folsomite"),
+     ".", Base, ".", space2dot(K), " ", a2l(V), " ", Timestamp, "\n"].
 
 num2str(NN) -> lists:flatten(io_lib:format("~w",[NN])).
 unixtime()  -> {Meg, S, _} = os:timestamp(), Meg*1000000 + S.


### PR DESCRIPTION
This makes the metrics prefix configurable.
Useful for heroku deployments with hosted-graphite, which requires the prefix to be an API key.