### PR TITLE
Add metric prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-ebin/*.app
-ebin/*.beam
+*.beam
 deps
+ebin/*.app


### PR DESCRIPTION
Some graphite services require that the API key for the
service (e.g. hostedgraphite) is inserted into the metric name
itself. This patch allows to insert this into the metric name.

Otherwise, it is required that some kind of proxy/relay is used in order
to accomplish this (such as graphite-carbon-relay).