### PR TITLE
Allow metric names to be lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ebin/*.app
 ebin/*.beam
 deps
 _build
+.eunit/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ otp_release:
   - 17.5
   - 18.1
 
-script: ./rebar3 update && ./rebar3 dialyzer
+script: ./rebar3 update && ./rebar3 dialyzer && ./rebar3 eunit


### PR DESCRIPTION
`hackney` uses lists containing atoms for its metric names. Those would
be left as-is in the message sent to Graphite, which resulted in
`Bad value on output port 'tcp_inet'` errors since an `iolist` cannot
include atoms.

`a2l` now uses the `io_lib:printable_unicode_list` heuristic to guess
whether a list is a string or a sequence of tokens.

Minimal tests were added as well.